### PR TITLE
Migrate state to HSL from RGB

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,7 @@ import styled, { ThemeProvider } from 'styled-components';
 import GlobalStyles from 'styles/global';
 import colorConvert from 'colorConvert';
 import { randomRgbValues, trueMod, initializeGA, hslTo4x } from 'helpers';
-import { localStorageStrings, pageTitle } from 'config';
+import config from 'config';
 import { dark, light } from 'styles/themes';
 import breakpoints from 'styles/breakpoints';
 import Preview from 'components/Preview';
@@ -53,6 +53,7 @@ const randomizeColorState = () => {
 initializeGA();
 
 function App({ initialColorHsl, location }) {
+  const { localStorageStrings, pageTitle } = config;
   const [darkThemeToggle, setDarkThemeToggle] = useLocalStorageState(
     localStorageStrings.theme,
     true

--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ import { randomRgbValues, trueMod, initializeGA, hslTo4x } from 'helpers';
 import config from 'config';
 import { dark, light } from 'styles/themes';
 import breakpoints from 'styles/breakpoints';
-import Preview from 'components/Preview';
+import ColorDisplay from 'components/ColorDisplay';
 import Header from 'components/Header';
 import Footer from 'components/Footer';
 import ColorAdjustControls from 'components/ColorAdjustControls';
@@ -94,14 +94,14 @@ function App({ initialColorHsl, location }) {
   const adjustSat = sat => {
     const [h, s, l] = colorValues.hsl4x;
     const adjustment = sat * 4;
-    const newSat = s + adjustment > 399 ? 399 : s + adjustment < 1 ? 1 : s + adjustment;
+    const newSat = s + adjustment > 399 ? 399 : s + adjustment < 0 ? 0 : s + adjustment;
     setColorHslPrecise([h, newSat, l]);
   };
 
   const adjustLum = lum => {
     const [h, s, l] = colorValues.hsl4x;
     const adjustment = lum * 4;
-    const newLum = l + adjustment > 399 ? 399 : l + adjustment < 1 ? 1 : l + adjustment;
+    const newLum = l + adjustment > 399 ? 399 : l + adjustment < 0 ? 0 : l + adjustment;
     setColorHslPrecise([h, s, newLum]);
   };
 
@@ -134,7 +134,7 @@ function App({ initialColorHsl, location }) {
         />
         <Header state={{ darkThemeToggle }} callbacks={{ toggleTheme, randomizeColor }} />
         <ValueInputs setColor={setColorHslPrecise} colorValues={colorValues} />
-        <Preview
+        <ColorDisplay
           colorValues={colorValues}
           setColor={setColorHslPrecise}
           userMessages={userMessages}

--- a/src/colorConvert.js
+++ b/src/colorConvert.js
@@ -1,7 +1,7 @@
 import { trueMod } from 'helpers';
-import { hslScaleFactor } from 'config';
+import config from 'config';
 
-const HSL_SCALE = hslScaleFactor;
+const HSL_SCALE = config.hslScaleFactor;
 
 // 'fff'/'FFFFFF' -> ['FF', 'FF', 'FF']
 const splitHex = hexValue => {

--- a/src/colorConvert.js
+++ b/src/colorConvert.js
@@ -1,4 +1,7 @@
 import { trueMod } from 'helpers';
+import { hslScaleFactor } from 'config';
+
+const HSL_SCALE = hslScaleFactor;
 
 // 'fff'/'FFFFFF' -> ['FF', 'FF', 'FF']
 const splitHex = hexValue => {
@@ -23,23 +26,23 @@ const rgbToHex = rgbValues => {
     .toUpperCase();
 };
 
-// [255, 255, 255] -> [0, 0, 100]
+// [255, 255, 255] -> [1440, 400, 400]
 // https://en.wikipedia.org/wiki/HSL_and_HSV#HSL_to_RGB
 // https://stackoverflow.com/questions/39118528/rgb-to-hsl-conversion
 // https://www.niwa.nu/2013/05/math-behind-colorspace-conversions-rgb-hsl/
-const rgbToHsl = rgbValues => {
+const rgbToHsl4x = rgbValues => {
   // convert to value between 0 and 1
   const rgb = rgbValues.map(n => parseInt(n) / 255);
   const [min, max] = [Math.min(...rgb), Math.max(...rgb)];
   const L = (min + max) / 2;
-  const lum = Math.round(L * 100);
+  const lum = Math.round(L * 100 * HSL_SCALE);
 
   // no sat, so no hue, we have a shade of gray
   if (max === min) return [0, 0, lum];
 
   const chroma = max - min;
   const S = chroma / (1 - Math.abs(2 * L - 1));
-  const sat = Math.round(S * 100);
+  const sat = Math.round(S * 100 * HSL_SCALE);
 
   const [R, G, B] = rgb;
   const hueMaxChannel = {
@@ -48,9 +51,14 @@ const rgbToHsl = rgbValues => {
     '2': (R - G) / chroma + 4
   };
   const H = hueMaxChannel[rgb.indexOf(max)];
-  const hue = Math.round(H * 60);
-
+  const hue = Math.round(H * 60 * HSL_SCALE);
   return [hue, sat, lum];
+};
+
+// [255, 255, 255] -> [360, 100, 100]
+const rgbToHsl = rgbValues => {
+  const hsl4x = rgbToHsl4x(rgbValues);
+  return hsl4x.map(v => Math.round(v / 4));
 };
 
 // 'FFF'/'FFFFFF' -> [255, 255, 255]
@@ -58,16 +66,22 @@ const hexToRgb = hexValue => {
   return splitHex(hexValue).map(h => parseInt(h, 16));
 };
 
-// 'FFF'/'FFFFFF' -> [0, 0, 100]
+// 'FFF'/'FFFFFF' -> [360, 100, 100]
 const hexToHsl = hexValue => {
   const rgbValues = hexToRgb(hexValue);
   return rgbToHsl(rgbValues);
 };
 
-// [0, 0, 100] -> '255, 255, 255'
+// 'FFF'/'FFFFFF' -> [1440, 400, 400]
+const hexToHsl4x = hexValue => {
+  const rgbValues = hexToRgb(hexValue);
+  return rgbToHsl4x(rgbValues);
+};
+
+// [1440, 400, 400] -> '255, 255, 255'
 // https://www.niwa.nu/2013/05/math-behind-colorspace-conversions-rgb-hsl/
-const hslToRgb = hslValues => {
-  let [H, S, L] = hslValues.map(v => parseInt(v));
+const hsl4xToRgb = hslValues4x => {
+  let [H, S, L] = hslValues4x.map(v => parseInt(v) / HSL_SCALE);
 
   const sat = S / 100;
   const lum = L / 100;
@@ -94,19 +108,34 @@ const hslToRgb = hslValues => {
     if (3 * val < 2) return y + (x - y) * (2 / 3 - val) * 6;
     return y;
   };
-  return protoRBG.map(calcValue).map(v => trueMod(Math.round(255 * v), 255));
-  // return protoRBG.map(calcValue).map(v => Math.round(255 * v));
+  // beware modulo and off-by-1s! 256 here, not 255
+  return protoRBG.map(calcValue).map(v => trueMod(Math.round(255 * v), 256));
 };
 
-// [0, 0, 100] -> 'ffffff'
+const hslToRgb = hslValues => {
+  return hsl4xToRgb(hslValues.map(v => v * 4));
+};
+
+// [360, 100, 100] -> 'ffffff'
 const hslToHex = hslValues => {
   const rgbValues = hslToRgb(hslValues.map(v => parseInt(v)));
+  return rgbToHex(rgbValues);
+};
+
+// [1440, 400, 400] -> 'ffffff'
+const hsl4xToHex = hslValues4x => {
+  const rgbValues = hsl4xToRgb(hslValues4x);
   return rgbToHex(rgbValues);
 };
 
 const hslValuesToCSS = hslValues => {
   const [H, S, L] = hslValues;
   return `hsl(${H}, ${S}%, ${L}%)`;
+};
+
+const hslValues4xToCSS = hslValues4x => {
+  const [H, S, L] = hslValues4x;
+  return `hsl(${H / 4}, ${S / 4}%, ${L / 4}%)`;
 };
 
 const rgbValuesToCSS = rgbValues => {
@@ -119,19 +148,26 @@ const hexValuesToCSS = hexValue => {
 };
 
 export default {
-  rgb: {
-    toHex: rgbToHex,
-    toHsl: rgbToHsl,
-    toCSS: rgbValuesToCSS
+  hsl4x: {
+    toRgb: hsl4xToRgb,
+    toHex: hsl4xToHex,
+    toCSS: hslValues4xToCSS
   },
   hsl: {
     toRgb: hslToRgb,
     toHex: hslToHex,
     toCSS: hslValuesToCSS
   },
+  rgb: {
+    toHsl: rgbToHsl,
+    toHsl4x: rgbToHsl4x,
+    toHex: rgbToHex,
+    toCSS: rgbValuesToCSS
+  },
   hex: {
-    toRgb: hexToRgb,
     toHsl: hexToHsl,
+    toHsl4x: hexToHsl4x,
+    toRgb: hexToRgb,
     toCSS: hexValuesToCSS,
     normalize: hex => splitHex(hex).join('')
   }

--- a/src/colorConvertAlternate.js
+++ b/src/colorConvertAlternate.js
@@ -1,0 +1,168 @@
+// https://jsfiddle.net/Lamik/9rky6fco/
+
+export const hsv2hsl = (h, s, v, l = v - (v * s) / 2, m = Math.min(l, 1 - l)) => [
+  h,
+  m ? (v - l) / m : 0,
+  l
+];
+
+export function hsv2hsl_indirect(h, s, v) {
+  return rgb2hsl_wiki(...hsv2rgb_wiki(h, s, v));
+}
+
+export function hsv2rgb_wiki(h, s, v) {
+  let c = v * s;
+  let k = h / 60;
+  let x = c * (1 - Math.abs((k % 2) - 1));
+
+  let [r1, g1, b1] = [0, 0, 0];
+
+  // let r1 = (g1 = b1 = 0);
+
+  if (k >= 0 && k <= 1) {
+    r1 = c;
+    g1 = x;
+  }
+  if (k > 1 && k <= 2) {
+    r1 = x;
+    g1 = c;
+  }
+  if (k > 2 && k <= 3) {
+    g1 = c;
+    b1 = x;
+  }
+  if (k > 3 && k <= 4) {
+    g1 = x;
+    b1 = c;
+  }
+  if (k > 4 && k <= 5) {
+    r1 = x;
+    b1 = c;
+  }
+  if (k > 5 && k <= 6) {
+    r1 = c;
+    b1 = x;
+  }
+
+  let m = v - c;
+
+  return [r1 + m, g1 + m, b1 + m];
+}
+
+export const rgb2hsl_wiki = (r, g, b) => {
+  let a = Math.max(r, g, b); //max
+  let i = Math.min(r, g, b); //min
+  let n = a - i; //chroma
+  let l = (a + i) / 2; //lum
+  let f = 1 - Math.abs(a + i - 1);
+  let s = f ? n / f : 0;
+  let h = 0;
+  if (n) {
+    if (a === r) h = 60 * (0 + (g - b) / n);
+    if (a === g) h = 60 * (2 + (b - r) / n);
+    if (a === b) h = 60 * (4 + (r - g) / n);
+  }
+
+  return [(h < 0 ? h + 360 : h) % 360, s, l];
+};
+
+// https://github.com/Qix-/color-convert/blob/HEAD/conversions.js
+export const rgb_2_hsl = rgb => {
+  const r = rgb[0] / 255;
+  const g = rgb[1] / 255;
+  const b = rgb[2] / 255;
+  const min = Math.min(r, g, b);
+  const max = Math.max(r, g, b);
+  const delta = max - min;
+  let h;
+  let s;
+
+  if (max === min) {
+    h = 0;
+  } else if (r === max) {
+    h = (g - b) / delta;
+  } else if (g === max) {
+    h = 2 + (b - r) / delta;
+  } else if (b === max) {
+    h = 4 + (r - g) / delta;
+  }
+
+  h = Math.min(h * 60, 360);
+
+  if (h < 0) {
+    h += 360;
+  }
+
+  const l = (min + max) / 2;
+
+  if (max === min) {
+    s = 0;
+  } else if (l <= 0.5) {
+    s = delta / (max + min);
+  } else {
+    s = delta / (2 - max - min);
+  }
+
+  return [h, s * 100, l * 100];
+};
+
+//http://jscolor.com/examples/
+// line ~1133
+// line ~1312
+
+// r: 0-255
+// g: 0-255
+// b: 0-255
+//
+// returns: [ 0-360, 0-100, 0-100 ]
+//
+function RGB_HSV(r, g, b) {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  var n = Math.min(Math.min(r, g), b);
+  var v = Math.max(Math.max(r, g), b);
+  var m = v - n;
+  if (m === 0) {
+    return [null, 0, 100 * v];
+  }
+  var h = r === n ? 3 + (b - g) / m : g === n ? 5 + (r - b) / m : 1 + (g - r) / m;
+  return [60 * (h === 6 ? 0 : h), 100 * (m / v), 100 * v];
+}
+
+// h: 0-360
+// s: 0-100
+// v: 0-100
+//
+// returns: [ 0-255, 0-255, 0-255 ]
+//
+function HSV_RGB(h, s, v) {
+  var u = 255 * (v / 100);
+
+  if (h === null) {
+    return [u, u, u];
+  }
+
+  h /= 60;
+  s /= 100;
+
+  var i = Math.floor(h);
+  var f = i % 2 ? h - i : 1 - (h - i);
+  var m = u * (1 - s);
+  var n = u * (1 - s * f);
+  switch (i) {
+    case 6:
+    case 0:
+      return [u, n, m];
+    case 1:
+      return [n, u, m];
+    case 2:
+      return [m, u, n];
+    case 3:
+      return [m, n, u];
+    case 4:
+      return [n, m, u];
+    case 5:
+      return [u, m, n];
+  }
+}

--- a/src/components/ColorAdjustControls.js
+++ b/src/components/ColorAdjustControls.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import colorConvert from 'colorConvert';
 import breakpoints from 'styles/breakpoints';
 import { recordGAEvent, hslTo4x } from 'helpers';
 
@@ -60,7 +59,7 @@ const Labels = styled.div`
 `;
 
 const ColorAdjustControls = ({ setColor, colorValues }) => {
-  let [h, s, l] = colorValues.hsl;
+  let [h, s, l] = colorValues.hslNormalized;
 
   const scaleUpAndSet = hslValues => {
     setColor(hslTo4x(hslValues));

--- a/src/components/ColorAdjustControls.js
+++ b/src/components/ColorAdjustControls.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import colorConvert from 'colorConvert';
 import breakpoints from 'styles/breakpoints';
-import { recordGAEvent } from 'helpers';
+import { recordGAEvent, hslTo4x } from 'helpers';
 
 const Styles = styled.div`
   margin: 0 -2rem 0;
@@ -62,9 +62,8 @@ const Labels = styled.div`
 const ColorAdjustControls = ({ setColor, colorValues }) => {
   let [h, s, l] = colorValues.hsl;
 
-  const convertAndSet = hslValues => {
-    const rgbValues = colorConvert.hsl.toRgb(hslValues);
-    setColor(rgbValues);
+  const scaleUpAndSet = hslValues => {
+    setColor(hslTo4x(hslValues));
   };
 
   const lumValues = [12, 24, 36, 50, 62, 74, 86];
@@ -85,7 +84,7 @@ const ColorAdjustControls = ({ setColor, colorValues }) => {
                 h={h}
                 l={lum}
                 s={s}
-                onClick={() => convertAndSet([h, s, lum])}
+                onClick={() => scaleUpAndSet([h, s, lum])}
                 title={`Set lightness to %`}
                 style={{
                   background: `hsl(${h}, ${s}%, ${lum}%)`
@@ -108,7 +107,7 @@ const ColorAdjustControls = ({ setColor, colorValues }) => {
                 h={h}
                 l={l}
                 s={sat}
-                onClick={() => convertAndSet([h, sat, l])}
+                onClick={() => scaleUpAndSet([h, sat, l])}
                 title={`Set saturation to %`}
                 style={{
                   background: `hsl(${h}, ${sat}%, 50%)`

--- a/src/components/ColorDisplay.js
+++ b/src/components/ColorDisplay.js
@@ -13,7 +13,7 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import config from 'config';
 import { recordGAEvent, isBright } from 'helpers';
 
-const ColorDisplay = styled(animated.div)`
+const Styles = styled(animated.div)`
   height: 30vh;
   min-height: 25rem;
   margin: 0 -2rem 0;
@@ -70,7 +70,7 @@ const LinkTo = ({ hex, addMessage, isBright }) => {
   );
 };
 
-export default function Preview({ colorValues, setColor, userMessages }) {
+export default function ColorDisplay({ colorValues, setColor, userMessages }) {
   const [showingHarmony, setShowingHarmony] = useState(null);
   const isBrightBg = isBright(...colorValues.rgb);
   const rgbCSS = colorConvert.rgb.toCSS(colorValues.rgb);
@@ -86,7 +86,7 @@ export default function Preview({ colorValues, setColor, userMessages }) {
 
   return (
     <Container>
-      <ColorDisplay style={colorTransition}>
+      <Styles style={colorTransition}>
         <ColorValues colorValues={colorValues} addMessage={userMessages.add} />
         <UserNotify isBright={isBrightBg} messages={userMessages} />
         <HarmonyDisplay
@@ -96,7 +96,7 @@ export default function Preview({ colorValues, setColor, userMessages }) {
           addMessage={userMessages.add}
         />
         <LinkTo hex={colorValues.hex} addMessage={userMessages.add} isBright={isBrightBg} />
-      </ColorDisplay>
+      </Styles>
       <HarmonyToggle showing={showingHarmony} setShowing={setShowingHarmony} />
     </Container>
   );

--- a/src/components/ColorValues.js
+++ b/src/components/ColorValues.js
@@ -4,6 +4,7 @@ import colorConvert from 'colorConvert';
 import { animated, useSpring } from 'react-spring';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { recordGAEvent, isBright } from 'helpers';
+import config from 'config';
 
 const StyledDiv = styled.div`
   display: flex;
@@ -43,7 +44,7 @@ const CopyOnClick = ({ string, children, addMessage }) => {
 
 export default function ColorValues({ colorValues, addMessage }) {
   const values = useSpring({
-    config: { duration: 400 },
+    config: { duration: config.transitionDurationMs },
     rgb: colorValues.rgb,
     hsl: colorValues.hsl
   });

--- a/src/components/HarmonyDisplay.js
+++ b/src/components/HarmonyDisplay.js
@@ -4,12 +4,11 @@ import colorConvert from 'colorConvert';
 import breakpoints from 'styles/breakpoints';
 import { useSpring, animated } from 'react-spring';
 import { trueMod, recordGAEvent, isBright } from 'helpers';
-import { harmonyConstants } from 'config';
+import config from 'config';
 import IconButton from 'components/common/IconButton';
 import { ReactComponent as MaxIcon } from 'icons/maximize.svg';
 import { ReactComponent as LinkIcon } from 'icons/link.svg';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { publicURL } from 'config';
 
 const Styles = styled.div``;
 
@@ -69,15 +68,16 @@ const Buttons = styled.div`
 const Swatch = ({ hex, setColor, addMessage }) => {
   const [r, g, b] = colorConvert.hex.toRgb(hex);
   const isBrightBg = isBright(r, g, b);
+  const duration = config.transitionDurationMs;
   const valuesSpring = useSpring({
-    config: { duration: 400 },
+    config: { duration },
     rgb: [r, g, b]
   });
   const backgroundSpring = useSpring({
-    config: { duration: 400 },
+    config: { duration },
     background: `#${hex}`
   });
-  const link = `${publicURL}/hex/${hex}`;
+  const link = `${config.publicURL}/hex/${hex}`;
 
   return (
     <AnimatedSwatch style={backgroundSpring} isBright={isBrightBg}>
@@ -162,6 +162,7 @@ const getTetradicValues = ([h, s, l]) => {
 
 export default function HarmonyDisplay({ colorValues, showing, setColor, addMessage }) {
   const { hsl } = colorValues;
+  const { harmonyConstants } = config;
 
   // key must be index for spring animations to work
   return (

--- a/src/components/HarmonyDisplay.js
+++ b/src/components/HarmonyDisplay.js
@@ -99,7 +99,7 @@ const Swatch = ({ hex, setColor, addMessage }) => {
         <IconButton
           title="Set base color"
           onClick={() => {
-            setColor([r, g, b]);
+            setColor(colorConvert.rgb.toHsl4x([r, g, b]));
             recordGAEvent('User', 'Clicked', 'Set base color');
           }}
         >

--- a/src/components/HarmonyToggle.js
+++ b/src/components/HarmonyToggle.js
@@ -7,7 +7,7 @@ import { ReactComponent as AnaloIcon } from 'icons/harm-anl.svg';
 import { ReactComponent as SplitIcon } from 'icons/harm-spt.svg';
 import { ReactComponent as TriIcon } from 'icons/harm-tri.svg';
 import { ReactComponent as TetIcon } from 'icons/harm-tet.svg';
-import { harmonyConstants } from 'config';
+import config from 'config';
 import { recordGAEvent } from 'helpers';
 
 const Styles = styled.div``;
@@ -24,6 +24,7 @@ const Toggle = styled.div`
 `;
 
 export default function HarmonyToggle({ showing, setShowing }) {
+  const { harmonyConstants } = config;
   const toggle = harmony => {
     if (showing === harmony) {
       setShowing(null);

--- a/src/components/HexForm.js
+++ b/src/components/HexForm.js
@@ -11,12 +11,11 @@ const HexForm = ({ setColor, colorValues }) => {
     setHexValue(colorValues.hex);
   }, [colorValues.hex]);
 
-  const handleChange = (e, value, name) => {
+  const handleChange = (e, value) => {
     setHexValue(() => {
       if (value.length === 6) {
         setInputError(false);
-        const rgbValues = colorConvert.hex.toRgb(value);
-        setColor(rgbValues);
+        setColor(colorConvert.hex.toHsl4x(value));
       } else {
         setInputError(true);
       }

--- a/src/components/HotKeys.js
+++ b/src/components/HotKeys.js
@@ -3,6 +3,7 @@ import useHotKeys from 'hooks/useHotKeys';
 import { fireHotKey, recordGAEvent } from 'helpers';
 import styled from 'styled-components';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { env } from 'config';
 
 const Hidden = styled.div`
   display: none;
@@ -74,6 +75,12 @@ export default function HotKeys({ callbacks, colorValues }) {
         adjustSat(-5);
         addMessage('Sat -5%');
       });
+    },
+    l: e => {
+      if (env !== 'production')
+        fireHotKey(e, () => {
+          console.log(colorValues);
+        });
     }
   });
   return (

--- a/src/components/HotKeys.js
+++ b/src/components/HotKeys.js
@@ -3,7 +3,7 @@ import useHotKeys from 'hooks/useHotKeys';
 import { fireHotKey, recordGAEvent } from 'helpers';
 import styled from 'styled-components';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { env } from 'config';
+import config from 'config';
 
 const Hidden = styled.div`
   display: none;
@@ -77,7 +77,7 @@ export default function HotKeys({ callbacks, colorValues }) {
       });
     },
     l: e => {
-      if (env !== 'production')
+      if (config.env !== 'production')
         fireHotKey(e, () => {
           console.log(colorValues);
         });

--- a/src/components/HslForm.js
+++ b/src/components/HslForm.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import colorConvert from 'colorConvert';
+// import colorConvert from 'colorConvert';
 import DegreeInput from 'components/common/DegreeInput';
 import HectoInput from 'components/common/HectoInput';
-import { recordGAEvent } from 'helpers';
+import { recordGAEvent, hslTo4x } from 'helpers';
 
 const HslForm = ({ setColor, colorValues }) => {
   const [hslValues, setHslValues] = useState({ h: 0, s: 0, l: 0 });
@@ -16,9 +16,10 @@ const HslForm = ({ setColor, colorValues }) => {
     setHslValues(prev => {
       const newValues = { ...prev, [name]: value };
       let { h, s, l } = newValues;
-      if (prev.h === 0 && h > 0 && prev.s === 0) s = 50;
-      const rgbValues = colorConvert.hsl.toRgb([h, s, l]);
-      setColor(rgbValues);
+      // next line needed??
+      // if (prev.h === 0 && h > 0 && prev.s === 0) s = 50;
+      // const rgbValues = colorConvert.hsl.toRgb([h, s, l]);
+      setColor(hslTo4x([h, s, l]));
       return newValues;
     });
   };

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -10,7 +10,7 @@ import HarmonyToggle from 'components/HarmonyToggle';
 import IconButton from 'components/common/IconButton';
 import { ReactComponent as LinkIcon } from 'icons/link.svg';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { publicURL } from 'config';
+import config from 'config';
 import { recordGAEvent, isBright } from 'helpers';
 
 const ColorDisplay = styled(animated.div)`
@@ -51,7 +51,7 @@ const LinkToStyles = styled.div`
 `;
 
 const LinkTo = ({ hex, addMessage, isBright }) => {
-  const link = `${publicURL}/hex/${hex}`;
+  const link = `${config.publicURL}/hex/${hex}`;
 
   return (
     <LinkToStyles isBright={isBright}>
@@ -75,7 +75,7 @@ export default function Preview({ colorValues, setColor, userMessages }) {
   const isBrightBg = isBright(...colorValues.rgb);
   const rgbCSS = colorConvert.rgb.toCSS(colorValues.rgb);
   const colorTransition = useSpring({
-    config: { duration: 400 },
+    config: { duration: config.transitionDurationMs },
     background: rgbCSS
   });
 

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -74,7 +74,7 @@ export default function Preview({ colorValues, setColor, userMessages }) {
   const [showingHarmony, setShowingHarmony] = useState(null);
   const isBrightBg = isBright(...colorValues.rgb);
   const rgbCSS = colorConvert.rgb.toCSS(colorValues.rgb);
-  const color = useSpring({
+  const colorTransition = useSpring({
     config: { duration: 400 },
     background: rgbCSS
   });
@@ -86,7 +86,7 @@ export default function Preview({ colorValues, setColor, userMessages }) {
 
   return (
     <Container>
-      <ColorDisplay style={color}>
+      <ColorDisplay style={colorTransition}>
         <ColorValues colorValues={colorValues} addMessage={userMessages.add} />
         <UserNotify isBright={isBrightBg} messages={userMessages} />
         <HarmonyDisplay

--- a/src/components/RgbForm.js
+++ b/src/components/RgbForm.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import ByteInput from 'components/common/ByteInput';
 import { recordGAEvent } from 'helpers';
+import colorConvert from 'colorConvert';
 
 const RgbForm = ({ setColor, colorValues }) => {
   // TODO input valid state for invalid input indicator
@@ -15,7 +16,7 @@ const RgbForm = ({ setColor, colorValues }) => {
     setRgbValues(prev => {
       const newValues = { ...prev, [name]: value };
       const { r, g, b } = newValues;
-      setColor([r, g, b]);
+      setColor(colorConvert.rgb.toHsl4x([r, g, b]));
       return newValues;
     });
   };

--- a/src/components/ValueSliders.js
+++ b/src/components/ValueSliders.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import ColorInputRange from 'components/common/ColorInputRange';
-import colorConvert from 'colorConvert';
+import { hslScaleFactor } from 'config';
 import { recordGAEvent } from 'helpers';
 
 const StyledDiv = styled.div`
@@ -24,7 +24,7 @@ const SatScale = styled(ColorInputRange)`
     );
   }
   .input-range__slider {
-    background: ${p => `hsl(${p.hue}, ${p.value}%, 50%)`};
+    background: ${p => `hsl(${p.hue}, ${p.value / hslScaleFactor}%, 50%)`};
   }
 `;
 
@@ -38,7 +38,7 @@ const LumScale = styled(ColorInputRange)`
     );
   }
   .input-range__slider {
-    background: ${p => `hsl(${p.hue}, 100%, ${p.value}%)`};
+    background: ${p => `hsl(${p.hue}, 100%, ${p.value / hslScaleFactor}%)`};
   }
 `;
 
@@ -74,28 +74,28 @@ const HueScale = styled(ColorInputRange)`
     );
   }
   .input-range__slider {
-    background: ${p => `hsl(${p.value}, 100%, 50%)`};
+    background: ${p => `hsl(${p.value / hslScaleFactor}, 100%, 50%)`};
   }
 `;
 
 const ValuePicker = ({ setColor, colorValues }) => {
-  const [h, s, l] = colorValues.hsl;
+  const [h, s, l] = colorValues.hsl4x;
   const [values, setValues] = useState({ h, s, l });
 
   React.useEffect(() => {
-    const [h, s, l] = colorValues.hsl;
+    const [h, s, l] = colorValues.hsl4x;
     setValues({ h, s, l });
   }, [colorValues]);
 
   const set = ({ h, s, l }) => {
-    setColor(colorConvert.hsl.toRgb([h, s, l]));
+    setColor([h, s, l]);
   };
 
   const handleSetHue = h => {
     setValues(prev => {
       const values = { ...prev, h };
-      if (s === 0) values.s = 50;
-      if (l === 0) values.l = 50;
+      // if (s === 0) values.s = 50;
+      // if (l === 0) values.l = 50;
       set(values);
       return values;
     });
@@ -104,7 +104,7 @@ const ValuePicker = ({ setColor, colorValues }) => {
   const handleSetSat = s => {
     setValues(prev => {
       const values = { ...prev, s };
-      if (l === 0) values.l = 50;
+      // if (l === 0) values.l = 50;
       set(values);
       return values;
     });
@@ -122,15 +122,15 @@ const ValuePicker = ({ setColor, colorValues }) => {
     <StyledDiv onClick={() => recordGAEvent('User', 'Clicked', 'Slider controls')}>
       <SliderContainer>
         <label>Hue</label>
-        <HueScale maxValue={359} value={values.h} onChange={handleSetHue} />
+        <HueScale maxValue={1439} value={values.h} onChange={handleSetHue} />
       </SliderContainer>
       <SliderContainer>
         <label>Saturation</label>
-        <SatScale hue={values.h} maxValue={100} value={values.s} onChange={handleSetSat} />
+        <SatScale hue={values.h} maxValue={399} value={values.s} onChange={handleSetSat} />
       </SliderContainer>
       <SliderContainer>
         <label>Luminance</label>
-        <LumScale hue={values.h} maxValue={100} value={values.l} onChange={handleSetLum} />
+        <LumScale hue={values.h} maxValue={399} value={values.l} onChange={handleSetLum} />
       </SliderContainer>
     </StyledDiv>
   );

--- a/src/components/ValueSliders.js
+++ b/src/components/ValueSliders.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import ColorInputRange from 'components/common/ColorInputRange';
-import { hslScaleFactor } from 'config';
 import { recordGAEvent } from 'helpers';
 
 const StyledDiv = styled.div`
@@ -19,12 +18,12 @@ const SatScale = styled(ColorInputRange)`
   .input-range__track--background {
     background: linear-gradient(
       to right,
-      hsl(${p => p.hue}, 0%, 50%),
-      hsl(${p => p.hue}, 100%, 50%)
+      hsl(${p => p.hsl.h}, 0%, 50%),
+      hsl(${p => p.hsl.h}, 100%, 50%)
     );
   }
   .input-range__slider {
-    background: ${p => `hsl(${p.hue}, ${p.value / hslScaleFactor}%, 50%)`};
+    background: ${p => `hsl(${p.hsl.h}, ${p.hsl.s}%, 50%)`};
   }
 `;
 
@@ -32,13 +31,13 @@ const LumScale = styled(ColorInputRange)`
   .input-range__track--background {
     background: linear-gradient(
       to right,
-      hsl(${p => p.hue}, 100%, 0%),
-      hsl(${p => p.hue}, 100%, 50%),
-      hsl(${p => p.hue}, 100%, 100%)
+      hsl(${p => p.hsl.h}, 100%, 0%),
+      hsl(${p => p.hsl.h}, 100%, 50%),
+      hsl(${p => p.hsl.h}, 100%, 100%)
     );
   }
   .input-range__slider {
-    background: ${p => `hsl(${p.hue}, 100%, ${p.value / hslScaleFactor}%)`};
+    background: ${p => `hsl(${p.hsl.h}, 100%, ${p.hsl.l}%)`};
   }
 `;
 
@@ -74,13 +73,15 @@ const HueScale = styled(ColorInputRange)`
     );
   }
   .input-range__slider {
-    background: ${p => `hsl(${p.value / hslScaleFactor}, 100%, 50%)`};
+    background: ${p => `hsl(${p.hsl.h}, 100%, 50%)`};
   }
 `;
 
 const ValuePicker = ({ setColor, colorValues }) => {
-  const [h, s, l] = colorValues.hsl4x;
-  const [values, setValues] = useState({ h, s, l });
+  const [h4x, s4x, l4x] = colorValues.hsl4x;
+  const [normalH, normalS, normalL] = colorValues.hslNormalized;
+  const normalHsl = { h: normalH, s: normalS, l: normalL };
+  const [values, setValues] = useState({ h: h4x, s: s4x, l: l4x });
 
   React.useEffect(() => {
     const [h, s, l] = colorValues.hsl4x;
@@ -94,8 +95,6 @@ const ValuePicker = ({ setColor, colorValues }) => {
   const handleSetHue = h => {
     setValues(prev => {
       const values = { ...prev, h };
-      // if (s === 0) values.s = 50;
-      // if (l === 0) values.l = 50;
       set(values);
       return values;
     });
@@ -104,7 +103,6 @@ const ValuePicker = ({ setColor, colorValues }) => {
   const handleSetSat = s => {
     setValues(prev => {
       const values = { ...prev, s };
-      // if (l === 0) values.l = 50;
       set(values);
       return values;
     });
@@ -122,15 +120,27 @@ const ValuePicker = ({ setColor, colorValues }) => {
     <StyledDiv onClick={() => recordGAEvent('User', 'Clicked', 'Slider controls')}>
       <SliderContainer>
         <label>Hue</label>
-        <HueScale maxValue={1439} value={values.h} onChange={handleSetHue} />
+        <HueScale maxValue={1439} value={values.h} hsl={normalHsl} onChange={handleSetHue} />
       </SliderContainer>
       <SliderContainer>
         <label>Saturation</label>
-        <SatScale hue={values.h} maxValue={399} value={values.s} onChange={handleSetSat} />
+        <SatScale
+          hue={values.h}
+          maxValue={399}
+          value={values.s}
+          hsl={normalHsl}
+          onChange={handleSetSat}
+        />
       </SliderContainer>
       <SliderContainer>
         <label>Luminance</label>
-        <LumScale hue={values.h} maxValue={399} value={values.l} onChange={handleSetLum} />
+        <LumScale
+          hue={values.h}
+          maxValue={399}
+          value={values.l}
+          hsl={normalHsl}
+          onChange={handleSetLum}
+        />
       </SliderContainer>
     </StyledDiv>
   );

--- a/src/components/common/FullScreenModal.js
+++ b/src/components/common/FullScreenModal.js
@@ -24,7 +24,6 @@ const Styles = styled(animated.div)`
 
 export default function FullScreenModal({ children, onClickOff, isShowing }) {
   const overlayTransition = useTransition(isShowing, null, {
-    // config: { duration: 1000 },
     from: {
       opacity: 0
       // transform: 'scale(1.15)'

--- a/src/config.js
+++ b/src/config.js
@@ -1,17 +1,20 @@
-export const harmonyConstants = {
-  CO: 'Complementary',
-  MO: 'Monochromatic',
-  AN: 'Analogous',
-  SP: 'Split Complementary',
-  TR: 'Triadic',
-  TE: 'Tetradic'
-};
-
-export const publicURL = 'https://color.joelb.dev';
-export const GAPropertyId = 'UA-140727716-1';
-export const env = process.env.NODE_ENV;
-export const pageTitle = 'Web color tool for developers | Convert RGB/HSL/Hex & explore harmonies';
-export const localStorageStrings = {
-  color: 'color-joeb-dev-color',
-  theme: 'color-joeb-dev-theme'
+export default {
+  localStorageStrings: {
+    color: 'color-joeb-dev-color-state',
+    theme: 'color-joeb-dev-theme-state'
+  },
+  publicURL: 'https://color.joelb.dev',
+  pageTitle: 'Web color tool for developers | Convert RGB/HSL/Hex & explore harmonies',
+  GAPropertyId: 'UA-140727716-1',
+  env: process.env.NODE_ENV,
+  transitionDurationMs: 400,
+  hslScaleFactor: 4,
+  harmonyConstants: {
+    CO: 'Complementary',
+    MO: 'Monochromatic',
+    AN: 'Analogous',
+    SP: 'Split Complementary',
+    TR: 'Triadic',
+    TE: 'Tetradic'
+  }
 };

--- a/src/config.js
+++ b/src/config.js
@@ -10,3 +10,8 @@ export const harmonyConstants = {
 export const publicURL = 'https://color.joelb.dev';
 export const GAPropertyId = 'UA-140727716-1';
 export const env = process.env.NODE_ENV;
+export const pageTitle = 'Web color tool for developers | Convert RGB/HSL/Hex & explore harmonies';
+export const localStorageStrings = {
+  color: 'color-joeb-dev-color',
+  theme: 'color-joeb-dev-theme'
+};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -52,3 +52,5 @@ export const isBrighterThan = (r, g, b, x) => perceivedBrightness(r, g, b) > x;
 
 // 123 is arbitrary but works well
 export const isBright = (r, g, b) => isBrighterThan(r, g, b, 123);
+
+export const hslTo4x = hslValues => hslValues.map(v => v * 4);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,6 @@
 import { hectoMatch, degreeMatch, byteMatch, hexColorMatch } from './regexDefs';
 import ReactGA from 'react-ga';
-import { env, GAPropertyId } from 'config';
+import config from 'config';
 
 export const validHsl = (h, s, l) =>
   degreeMatch.test(h) && hectoMatch.test(s) && hectoMatch.test(l);
@@ -27,15 +27,15 @@ export const fireHotKey = (e, callback) => {
 };
 
 export const initializeGA = () => {
-  if (env === 'production') {
-    ReactGA.initialize(GAPropertyId);
+  if (config.env === 'production') {
+    ReactGA.initialize(config.GAPropertyId);
   }
 };
 
 export const recordGAEvent = (category, action, label) => {
   if (!category || !action) {
     console.warn('GA Event: Category and action are required - aborting');
-  } else if (env === 'production') {
+  } else if (config.env === 'production') {
     const payload = {
       category,
       action

--- a/src/hooks/useAnalyticsPageView.js
+++ b/src/hooks/useAnalyticsPageView.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import ReactGA from 'react-ga';
-import { env } from 'config';
+import config from 'config';
 
 const useAnalyticsPageView = location => {
   React.useEffect(() => {
-    if (env === 'production') {
+    if (config.env === 'production') {
       ReactGA.pageview(location.pathname + location.search);
     }
   }, [location]);

--- a/src/index.js
+++ b/src/index.js
@@ -10,23 +10,23 @@ const Root = () => {
     // <React.StrictMode>
     <Router>
       <Switch>
-        <Route path="/" exact render={() => <App initialColor={null} />} />
+        <Route path="/" exact render={() => <App initialColorHsl={null} />} />
         <Route
           path="/hsl/:h/:s/:l"
           render={({ match }) => {
             const { h, s, l } = match.params;
-            return validHsl(h, s, l) ? (
-              <App initialColor={colorConvert.hsl.toRgb([h, s, l])} />
-            ) : (
-              <Redirect to="/" />
-            );
+            return validHsl(h, s, l) ? <App initialColorHsl={[h, s, l]} /> : <Redirect to="/" />;
           }}
         />
         <Route
           path="/rgb/:r/:g/:b"
           render={({ match }) => {
             const { r, g, b } = match.params;
-            return validRgb(r, g, b) ? <App initialColor={[r, g, b]} /> : <Redirect to="/" />;
+            return validRgb(r, g, b) ? (
+              <App initialColorHsl={colorConvert.rgb.toHsl([r, g, b])} />
+            ) : (
+              <Redirect to="/" />
+            );
           }}
         />
         <Route
@@ -34,7 +34,7 @@ const Root = () => {
           render={({ match }) => {
             const { hex } = match.params;
             return validHex(hex) ? (
-              <App initialColor={colorConvert.hex.toRgb(hex)} />
+              <App initialColorHsl={colorConvert.hex.toHsl(hex)} />
             ) : (
               <Redirect to="/" />
             );


### PR DESCRIPTION
App color state is now based on HSL values. This resolves the issue of a hue value being blown out if saturation or luminance were set to 0 or 100 by the user. When converting the RGB values to HSL for display, luminance values of 0 or 100 (black and white) cause hue to be undefined and reset to 0, degrading UX.